### PR TITLE
Fix TypeScript missing root keys of Options

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,11 +10,11 @@ interface GroupOptions {
 }
 
 interface Options {
-  force?: boolean;
   cwd?: string;
+  force?: boolean;
   minify?: boolean | 'auto';
   mergeFn?: (prev: json, current: json) => json;
-  group?: GroupOptions[];
+  group: GroupOptions[];
   globOptions?: GlobOptions;
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,25 +1,26 @@
 import { Options as GlobOptions } from 'fast-glob';
 import { Compiler } from 'webpack';
 
-type json = {} | { [key: string]: any }
+type json = {} | { [key: string]: any };
 
 interface GroupOptions {
   files: string[] | string;
-  beforeEmit?: (outputJson: json) => json
+  beforeEmit?: (outputJson: json) => json;
   to: string;
 }
 
 interface Options {
-  cwd: string;
-  minify: boolean | 'auto';
-  mergeFn: (prev: json, current: json) => json;
-  group: GroupOptions[];
-  globOptions: GlobOptions;
+  force?: boolean;
+  cwd?: string;
+  minify?: boolean | 'auto';
+  mergeFn?: (prev: json, current: json) => json;
+  group?: GroupOptions[];
+  globOptions?: GlobOptions;
 }
 
 declare class MergeJsonPlugin {
   constructor(options: Options);
-  apply(compiler: Compiler): void
+  apply(compiler: Compiler): void;
 }
 
 export = MergeJsonPlugin;


### PR DESCRIPTION
With current **src/index.d.ts** file, TypeScript will complain about missing keys provided to `Options` when invoking `new MergeJsonPlugin()`.

https://github.com/sibiraj-s/merge-json-webpack-plugin/blob/0a978c768f55349847bfe1f773665716044eccf8/src/index.js#L17-L24

https://github.com/sibiraj-s/merge-json-webpack-plugin/blob/0a978c768f55349847bfe1f773665716044eccf8/src/index.js#L33

From the above lines of code, since `defaultOptions` will be defaulted under `constructor`, root keys of `Options` should be made optional to fix this issue.